### PR TITLE
remove play call from createPlayer()

### DIFF
--- a/src/ofxVlcPlayer.cpp
+++ b/src/ofxVlcPlayer.cpp
@@ -172,7 +172,6 @@ void ofxVlcPlayer::createPlayer() {
     eventManager = libvlc_media_player_event_manager(mp);
     libvlc_event_attach(eventManager, libvlc_MediaPlayerEndReached, vlcEventStatic, this);
 
-    //~ libvlc_media_player_play(mp);
     libvlc_media_player_set_time(mp, 0);
 }
 

--- a/src/ofxVlcPlayer.cpp
+++ b/src/ofxVlcPlayer.cpp
@@ -172,7 +172,7 @@ void ofxVlcPlayer::createPlayer() {
     eventManager = libvlc_media_player_event_manager(mp);
     libvlc_event_attach(eventManager, libvlc_MediaPlayerEndReached, vlcEventStatic, this);
 
-    libvlc_media_player_play(mp);
+    //~ libvlc_media_player_play(mp);
     libvlc_media_player_set_time(mp, 0);
 }
 


### PR DESCRIPTION
Remove play call from `createPlayer()`. This fixes:

- ability to load video without having to immediately start playback; `play()` would need to be called explicitly by the user whenever they want playback to begin
- ability to toggle looping off via `setLoop()`